### PR TITLE
Fix delete_document return value

### DIFF
--- a/backend/app/services/upload/document_service.py
+++ b/backend/app/services/upload/document_service.py
@@ -101,12 +101,12 @@ class DocumentService:
         """
         document = await self.get_document(document_id, user_id)
         
-        await delete_file(document.file_path)
-        
+        delete_success = await delete_file(document.file_path)
+
         self.db.delete(document)
         self.db.commit()
-        
-        return True
+
+        return delete_success
 
     async def bulk_upload_documents(self, files: List[UploadFile], user_id: Optional[int] = None) -> List[Document]:
         """

--- a/docs/architecture/phase1_implementation.md
+++ b/docs/architecture/phase1_implementation.md
@@ -187,14 +187,14 @@ class DocumentService:
         """
         document = await self.get_document(document_id, user_id)
         
-        # Delete file from storage
-        await delete_file(document.file_path)
+        # Delete file from storage and capture result
+        delete_success = await delete_file(document.file_path)
         
         # Delete document record
         self.db.delete(document)
         self.db.commit()
-        
-        return True
+
+        return delete_success
 
     async def bulk_upload_documents(self, files: List[UploadFile], user_id: int) -> List[Document]:
         """


### PR DESCRIPTION
## Summary
- return the result of `delete_file` from `DocumentService.delete_document`
- document how delete now returns the success boolean

## Testing
- `pytest -q` *(fails: command not found)*