### PR TITLE
Add basic OCR processing service

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ The platform is built with a modular architecture, divided into the following ph
 8. **Administrative and User Interfaces**
 
 Each phase is implemented as a separate module with well-defined interfaces, allowing for independent development, testing, and deployment.
+After uploading a document, send `POST /api/ocr/{document_id}` to extract text from each page.
 
 ## Technology Stack
 

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,0 +1,7 @@
+from .models import Document, User, ExtractedText
+
+__all__ = [
+    "Document",
+    "User",
+    "ExtractedText",
+]

--- a/backend/app/api/routes/ocr.py
+++ b/backend/app/api/routes/ocr.py
@@ -1,0 +1,21 @@
+from typing import List
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from app.db.session import get_db
+from app.api.deps import get_current_user_or_dummy
+from app.schemas.extracted_text import ExtractedTextResponse
+from app.services.ocr.ocr_service import OCRService
+
+router = APIRouter()
+
+
+@router.post("/{document_id}", response_model=List[ExtractedTextResponse])
+async def ocr_document(
+    document_id: int,
+    db: Session = Depends(get_db),
+    current_user = Depends(get_current_user_or_dummy),
+):
+    service = OCRService(db)
+    result = await service.process_document(document_id, current_user.id)
+    return result

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -5,6 +5,7 @@ import os
 from dotenv import load_dotenv
 
 from app.api.routes import document
+from app.api.routes import ocr
 from app.db.session import engine
 from app.db.base import Base
 
@@ -28,6 +29,7 @@ app.add_middleware(
 )
 
 app.include_router(document.router, prefix="/api/documents", tags=["documents"])
+app.include_router(ocr.router, prefix="/api/ocr", tags=["ocr"])
 
 @app.get("/health", tags=["health"])
 async def health_check():

--- a/backend/app/models/__init__/__init__.py
+++ b/backend/app/models/__init__/__init__.py
@@ -1,0 +1,9 @@
+from .document import Document
+from .user import User
+from .extracted_text import ExtractedText
+
+__all__ = [
+    "Document",
+    "User",
+    "ExtractedText",
+]

--- a/backend/app/models/document.py
+++ b/backend/app/models/document.py
@@ -35,6 +35,12 @@ class Document(Base):
     created_at = Column(DateTime, default=datetime.utcnow)
     updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
 
+    extracted_texts = relationship(
+        "ExtractedText",
+        back_populates="document",
+        cascade="all, delete-orphan",
+    )
+
 
     def __repr__(self):
         return f"<Document {self.name}>"

--- a/backend/app/models/extracted_text.py
+++ b/backend/app/models/extracted_text.py
@@ -1,0 +1,22 @@
+from datetime import datetime
+from sqlalchemy import Column, Integer, String, ForeignKey, DateTime, Float, Text
+from sqlalchemy.orm import relationship
+
+from app.db.base import Base
+
+
+class ExtractedText(Base):
+    __tablename__ = "extracted_texts"
+
+    id = Column(Integer, primary_key=True, index=True)
+    document_id = Column(Integer, ForeignKey("documents.id", ondelete="CASCADE"))
+    text_content = Column(Text)
+    page_number = Column(Integer)
+    confidence = Column(Float, nullable=True)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    document = relationship("Document", back_populates="extracted_texts")
+
+    def __repr__(self):
+        return f"<ExtractedText doc={self.document_id} page={self.page_number}>"

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -1,0 +1,13 @@
+from .document import DocumentCreate, DocumentList, DocumentResponse, DocumentUpdate
+from .token import Token, TokenData
+from .extracted_text import ExtractedTextResponse
+
+__all__ = [
+    "DocumentCreate",
+    "DocumentList",
+    "DocumentResponse",
+    "DocumentUpdate",
+    "Token",
+    "TokenData",
+    "ExtractedTextResponse",
+]

--- a/backend/app/schemas/extracted_text.py
+++ b/backend/app/schemas/extracted_text.py
@@ -1,0 +1,22 @@
+from datetime import datetime
+from pydantic import BaseModel
+
+
+class ExtractedTextBase(BaseModel):
+    page_number: int
+    text_content: str
+
+
+class ExtractedTextCreate(ExtractedTextBase):
+    document_id: int
+
+
+class ExtractedTextResponse(ExtractedTextBase):
+    id: int
+    document_id: int
+    confidence: float | None = None
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        orm_mode = True

--- a/backend/app/services/ocr/__init__.py
+++ b/backend/app/services/ocr/__init__.py
@@ -1,0 +1,3 @@
+from .ocr_service import OCRService
+
+__all__ = ["OCRService"]

--- a/backend/app/services/ocr/ocr_service.py
+++ b/backend/app/services/ocr/ocr_service.py
@@ -1,0 +1,61 @@
+import fitz
+from typing import List
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+
+from app.models.document import Document, DocumentType, DocumentStatus
+from app.models.extracted_text import ExtractedText
+from app.utils.pdf_utils import is_searchable_pdf
+
+try:
+    import pytesseract
+    from PIL import Image
+except Exception:  # pragma: no cover
+    pytesseract = None  # type: ignore
+    Image = None  # type: ignore
+
+
+class OCRService:
+    def __init__(self, db: Session):
+        self.db = db
+
+    async def process_document(self, document_id: int, user_id: int) -> List[ExtractedText]:
+        document = (
+            self.db.query(Document)
+            .filter(Document.id == document_id, Document.user_id == user_id)
+            .first()
+        )
+        if not document:
+            raise HTTPException(status_code=404, detail="Document not found")
+
+        file_path = document.file_path
+        is_searchable = await is_searchable_pdf(file_path)
+
+        extracted_items: List[ExtractedText] = []
+        doc = fitz.open(file_path)
+
+        for page_number in range(len(doc)):
+            page = doc[page_number]
+            text = page.get_text()
+            if not text and not is_searchable and pytesseract and Image:
+                pix = page.get_pixmap()
+                img = Image.frombytes("RGB", [pix.width, pix.height], pix.samples)
+                text = pytesseract.image_to_string(img, lang="ara")
+
+            extracted = ExtractedText(
+                document_id=document.id,
+                page_number=page_number + 1,
+                text_content=text,
+                confidence=None,
+            )
+            self.db.add(extracted)
+            extracted_items.append(extracted)
+
+        document.status = DocumentStatus.PROCESSED
+        document.file_type = DocumentType.SEARCHABLE if is_searchable else DocumentType.SCANNED
+        self.db.commit()
+
+        for item in extracted_items:
+            self.db.refresh(item)
+
+        return extracted_items

--- a/backend/tests/api/test_ocr.py
+++ b/backend/tests/api/test_ocr.py
@@ -1,0 +1,32 @@
+import os
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.main import app
+from app.db.session import SessionLocal
+from app.models.document import Document
+
+client = TestClient(app)
+
+def create_test_pdf(path: str):
+    import fitz
+    doc = fitz.open()
+    page = doc.new_page()
+    page.insert_text((50, 50), "مرحبا")
+    doc.save(path)
+    doc.close()
+
+
+def test_ocr_document(tmp_path):
+    test_pdf = tmp_path / "ocr_test.pdf"
+    create_test_pdf(str(test_pdf))
+    with open(test_pdf, "rb") as f:
+        response = client.post("/api/documents/upload", files={"file": (test_pdf.name, f, "application/pdf")})
+    assert response.status_code == 200
+    doc_id = response.json()["id"]
+    response = client.post(f"/api/ocr/{doc_id}")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) > 0
+    assert data[0]["page_number"] == 1
+    assert "مرحبا" in data[0]["text_content"]


### PR DESCRIPTION
## Summary
- introduce ExtractedText model and schema
- create OCRService with endpoint for document OCR
- register new API route in backend
- extend README with OCR usage note
- add a small test for OCR processing

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*